### PR TITLE
Added rostopic to access NDI error values

### DIFF
--- a/components/code/mtsNDISerial.cpp
+++ b/components/code/mtsNDISerial.cpp
@@ -873,6 +873,10 @@ mtsNDISerial::Tool * mtsNDISerial::AddTool(const std::string & name,
         } else {
             tool->Position.SetReferenceFrame(mTrackerName);
         }
+        
+        // rmserror/indicator value (Aurora)
+        StateTable.AddData(tool->ErrorRMS, name + "RMSError");
+        tool->Interface->AddCommandReadState(StateTable, tool->ErrorRMS, "GetErrorRMS");
     }
 
     // update list of existing tools

--- a/ros/mtsNDISerialROS.cpp
+++ b/ros/mtsNDISerialROS.cpp
@@ -182,6 +182,8 @@ void mtsNDISerialROS::UpdatedToolsEventHandler(void)
                 (name, "GetPositionCartesian", mROSNamespace + "/" + rosName + "/position_cartesian_current");
             mROSBridge->AddPublisherFromCommandRead<prmPositionCartesianGet, geometry_msgs::PoseStamped>
                 (name, "GetPositionCartesianLocal", mROSNamespace + "/" + rosName + "/position_cartesian_local_current");
+            mROSBridge->AddPublisherFromCommandRead<double, std_msgs::Float64>
+                (name, "GetErrorRMS", mROSNamespace + "/" + rosName + "/error_value");
             manager->Connect(mROSBridgeName, name,
                              mTrackerName, name);
             // tf2


### PR DESCRIPTION
I checked if there was a specific ros message type for this. Due to the slightly ambiguous meaning of this value and it potentially having a different meaning on various NDI systems, I think a standard message fits. 